### PR TITLE
Fix playlist sync insert placement and make SponsorBlock optional

### DIFF
--- a/internal/api/sponsorblock/client.go
+++ b/internal/api/sponsorblock/client.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
-
-	"github.com/cufee/feedlr-yt/internal/utils"
 )
 
 type client struct {
@@ -20,9 +20,10 @@ var C *client
 var ErrRequestTimeout = errors.New("request timeout")
 
 func init() {
-	apiUrl := utils.MustGetEnv("SPONSORBLOCK_API_URL")
+	apiUrl := strings.TrimSpace(os.Getenv("SPONSORBLOCK_API_URL"))
 	if apiUrl == "" {
-		log.Fatal("SPONSORBLOCK_API_URL is empty")
+		log.Println("sponsorblock disabled: SPONSORBLOCK_API_URL is not set")
+		return
 	}
 
 	DefaultClient = &client{

--- a/internal/logic/videos.go
+++ b/internal/logic/videos.go
@@ -281,6 +281,9 @@ func GetPlayerPropsWithOpts(ctx context.Context, db database.Client, userId, vid
 	}
 
 	if options.WithSegments {
+		if sponsorblock.C == nil {
+			return playerProps, nil
+		}
 		segments, err := sponsorblock.C.GetVideoSegments(videoId)
 		if err == nil {
 			err := playerProps.AddSegments(segments...)

--- a/internal/logic/youtube_sync_test.go
+++ b/internal/logic/youtube_sync_test.go
@@ -86,3 +86,25 @@ func TestBuildPlaylistSyncPlanInsertPositionsAppendAtEnd(t *testing.T) {
 	is.Equal(plan.ToAdd[1].VideoID, "c")
 	is.Equal(plan.ToAdd[1].Position, int64(2))
 }
+
+func TestBuildPlaylistSyncPlanInsertPositionsIgnoreItemsPlannedForDelete(t *testing.T) {
+	is := is.New(t)
+
+	desired := []string{"n1", "a", "b", "c"}
+	remote := []playlistRemoteItem{
+		{ItemID: "stale-head", VideoID: "x", Position: 0},
+		{ItemID: "i-a", VideoID: "a", Position: 1},
+		{ItemID: "i-b", VideoID: "b", Position: 2},
+		{ItemID: "i-c", VideoID: "c", Position: 3},
+		{ItemID: "stale-tail", VideoID: "y", Position: 4},
+	}
+
+	plan := buildPlaylistSyncPlan(desired, remote, 4)
+	is.Equal(len(plan.ToDelete), 2)
+	is.Equal(plan.ToDelete[0], "stale-tail")
+	is.Equal(plan.ToDelete[1], "stale-head")
+
+	is.Equal(len(plan.ToAdd), 1)
+	is.Equal(plan.ToAdd[0].VideoID, "n1")
+	is.Equal(plan.ToAdd[0].Position, int64(0))
+}

--- a/internal/logic/youtube_tv_sync.go
+++ b/internal/logic/youtube_tv_sync.go
@@ -999,6 +999,9 @@ func (s *YouTubeTVSyncService) loadSponsorSegments(videoID string, categories []
 	if len(categories) == 0 {
 		return nil
 	}
+	if sponsorblock.C == nil {
+		return nil
+	}
 
 	raw, err := sponsorblock.C.GetVideoSegments(videoID, categories...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix playlist sync insertion planning to ignore remote items scheduled for deletion when computing insert anchors
- Execute playlist mutations delete-first, then insert, to keep ordering deterministic for each run
- Replace subtraction-based position sort comparator with explicit compare logic
- Add regression test covering stale-head scenario where insert should resolve to position 0
- Make SponsorBlock initialization optional when  is unset and guard call sites against nil client

## Validation
- ok  	github.com/cufee/feedlr-yt/internal/logic	(cached)
- 2026/02/07 16:55:39 sponsorblock disabled: SPONSORBLOCK_API_URL is not set
=== RUN   TestYouTubeSyncCryptoRoundTrip
--- PASS: TestYouTubeSyncCryptoRoundTrip (0.00s)
=== RUN   TestBuildPlaylistSyncPlanSplitBudget
--- PASS: TestBuildPlaylistSyncPlanSplitBudget (0.00s)
=== RUN   TestBuildPlaylistSyncPlanBudgetBorrowing
--- PASS: TestBuildPlaylistSyncPlanBudgetBorrowing (0.00s)
=== RUN   TestBuildPlaylistSyncPlanInsertPositionsPreserveFeedOrder
--- PASS: TestBuildPlaylistSyncPlanInsertPositionsPreserveFeedOrder (0.00s)
=== RUN   TestBuildPlaylistSyncPlanInsertPositionsAppendAtEnd
--- PASS: TestBuildPlaylistSyncPlanInsertPositionsAppendAtEnd (0.00s)
=== RUN   TestBuildPlaylistSyncPlanInsertPositionsIgnoreItemsPlannedForDelete
--- PASS: TestBuildPlaylistSyncPlanInsertPositionsIgnoreItemsPlannedForDelete (0.00s)
=== RUN   TestNormalizeSponsorSegments
--- PASS: TestNormalizeSponsorSegments (0.00s)
PASS
ok  	github.com/cufee/feedlr-yt/internal/logic	(cached)

## Notes
- Home page ordering semantics were intentionally not changed in this PR; that requires separate design work.