### PR TITLE
Tune home feed ordering and fetch window

### DIFF
--- a/internal/database/channels.go
+++ b/internal/database/channels.go
@@ -84,7 +84,9 @@ func (c *sqliteClient) GetChannels(ctx context.Context, o ...ChannelQuery) ([]*m
 		sql := sqlbuilder.
 			Select("*").
 			From(models.TableNames.Videos).
-			Desc().OrderBy(models.VideoColumns.PublishedAt)
+			Desc().OrderBy(models.VideoColumns.PublishedAt).
+			Desc().OrderBy(models.VideoColumns.CreatedAt).
+			Desc().OrderBy(models.VideoColumns.ID)
 		sql = sql.Where(
 			sql.And(
 				sql.In(models.VideoColumns.ChannelID, ids...),
@@ -196,7 +198,9 @@ func (c *sqliteClient) GetChannel(ctx context.Context, channelId string, o ...Ch
 		sql := sqlbuilder.
 			Select("*").
 			From(models.TableNames.Videos).
-			Desc().OrderBy(models.VideoColumns.PublishedAt)
+			Desc().OrderBy(models.VideoColumns.PublishedAt).
+			Desc().OrderBy(models.VideoColumns.CreatedAt).
+			Desc().OrderBy(models.VideoColumns.ID)
 		sql = sql.Where(
 			sql.And(
 				sql.EQ(models.VideoColumns.ChannelID, channel.ID),

--- a/internal/database/videos.go
+++ b/internal/database/videos.go
@@ -107,7 +107,8 @@ func (c *sqliteClient) FindVideos(ctx context.Context, o ...VideoQuery) ([]*mode
 
 	sql := withSelect.
 		From(models.TableNames.Videos).
-		OrderBy(models.ViewColumns.CreatedAt).Desc()
+		OrderBy(models.VideoColumns.CreatedAt).Desc().
+		OrderBy(models.VideoColumns.ID).Desc()
 	if opts.limit > 0 {
 		sql = sql.Limit(opts.limit)
 	}


### PR DESCRIPTION
## Summary
- Fix `FindVideos` ordering to use video fields (`videos.created_at`) instead of `views.created_at`
- Add deterministic tie-breakers in DB and in-memory sorting (`created_at`, then `id`)
- Increase home feed fetch window before filtering/splitting and cap final output to existing home limit

## Files
- `internal/database/videos.go`
- `internal/database/channels.go`
- `internal/logic/videos.go`

## Validation
- `go test ./internal/logic`
- `go test ./internal/database -run '^$'`
