### PR TITLE
Match legal header height to app header

### DIFF
--- a/internal/templates/components/ui/navbar.templ
+++ b/internal/templates/components/ui/navbar.templ
@@ -17,7 +17,7 @@ templ Navbar(path string, authenticated bool) {
 
 templ NavbarLogoOnly(homeURL string) {
 	<div id="nav-indicator" class="ui-nav-shell">
-		<div class="flex min-h-11 items-center">
+		<div class="flex min-h-[50px] items-center">
 			<a href={ homeURL } class="inline-flex items-center py-1">
 				@shared.Logo()
 			</a>

--- a/internal/templates/components/ui/navbar.templ
+++ b/internal/templates/components/ui/navbar.templ
@@ -26,7 +26,7 @@ templ NavbarLogoOnly(homeURL string) {
 }
 
 templ navbarAuthenticated(path string) {
-	<div class="flex items-center justify-between gap-3">
+	<div class="flex min-h-[50px] items-center justify-between gap-3">
 		<a href="/app" class="inline-flex items-center py-1">
 			@shared.Logo()
 		</a>
@@ -45,7 +45,7 @@ templ navbarAuthenticated(path string) {
 }
 
 templ navbarGuest(path string) {
-	<div class="flex items-center justify-between gap-3">
+	<div class="flex min-h-[50px] items-center justify-between gap-3">
 		<a href="/" class="inline-flex items-center py-1">
 			@shared.Logo()
 		</a>


### PR DESCRIPTION
## Summary
- set the legal logo-only header content row to `min-h-[50px]` so it matches the app header chrome height

## Why
- production legal pages currently render a shorter header than app pages

## Validation
- `npm run build`
- `go test ./internal/templates/... ./internal/server/routes/...`
