### PR TITLE
Frontend cleanup sweep and docs alignment

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -24,8 +24,7 @@ internal/templates/
 │   ├── blank.templ       # Minimal layout
 │   └── partials/         # Shared layout parts
 │       ├── head.templ    # CSS/JS includes
-│       ├── navbar.templ  # Navigation bar
-│       └── progress.templ # HTMX progress bar
+│       └── navbar.templ  # Navigation wrapper for app shell
 ├── pages/                # Full pages
 │   ├── landing.templ
 │   ├── login.templ
@@ -51,9 +50,9 @@ Current primitives:
 - `button.templ` (`Button`, variants/sizes)
 - `input.templ` (`Input`, `SearchInput`)
 - `layout.templ` (`Card`, `Section`, `Badge`, `EmptyState`)
-- `tabs.templ` (`Tabs`, `TabButton`)
-- `toggle.templ` (`Toggle`, `ToggleWithLabel`)
-- `dialog.templ` (`Dialog`, `DialogBackdropButton`)
+- `tabs.templ` (`Tabs`)
+- `toggle.templ` (`Toggle`)
+- `dialog.templ` (`Dialog`)
 - `toast.templ` (`Toast`)
 - `pageshell.templ` (`PageShellMain`, `PageShellFooter`, `PageShellVideo`)
 - `navbar.templ` (`Navbar`, guest/authed variants)
@@ -393,8 +392,8 @@ npm run dev    # Watch mode
 // Using templ.KV
 <div class={ "ui-tab", templ.KV("ui-tab-active", isActive) }>
 
-// Using helper function
-<input class={ "ui-input", shared.OptionalClass(!valid, "ui-input-error") } />
+// Conditional class only when invalid
+<input class={ "ui-input", templ.KV("ui-input-error", !valid) } />
 ```
 
 ## File Reference

--- a/docs/LIQUID-GLASS-REDESIGN.md
+++ b/docs/LIQUID-GLASS-REDESIGN.md
@@ -16,14 +16,14 @@ Reviewed sources:
 - Apple Liquid Glass overview: https://developer.apple.com/documentation/TechnologyOverviews/liquid-glass
 - Apple adopting Liquid Glass: https://developer.apple.com/documentation/TechnologyOverviews/adopting-liquid-glass
 - Apple HIG materials: https://developer.apple.com/design/human-interface-guidelines/materials
-- Tailwind with Vite: https://tailwindcss.com/docs/installation/using-vite
+- Tailwind with CLI build: https://tailwindcss.com/docs/installation/tailwind-cli
 
 Key takeaways used in this plan:
 
 - Liquid Glass emphasizes dynamic translucency, layering, and adaptive behavior based on context.
 - Adoption guidance emphasizes using system conventions, preserving legibility, and avoiding decorative overuse.
 - HIG materials emphasize hierarchy, harmony, and consistency across surfaces.
-- Tailwind + Vite setup should be simple and explicit: install `tailwindcss` and `@tailwindcss/vite`, register the Vite plugin, and import Tailwind in the app CSS entry.
+- Tailwind CLI setup should stay explicit and minimal: keep `tailwind.css` as source and compile to `assets/css/style.css`.
 
 ## Current Frontend Baseline
 
@@ -45,7 +45,7 @@ Key takeaways used in this plan:
 
 Create a "Polar Glass" UI language:
 
-- Cool neutral palette with high contrast text, subtle cyan accents, no purple bias
+- Cool neutral palette with high contrast text and restrained violet accents
 - Frosted translucent panels over soft atmospheric gradients
 - Crisp boundaries (hairline borders) with restrained blur and saturation
 - Utility-first layout prioritizing video scanning speed over decorative density
@@ -135,14 +135,14 @@ Rules:
 - Keep custom CSS small and tokenized; prefer Tailwind classes in templates first.
 - Add custom CSS only for reusable patterns that cannot be expressed readably with Tailwind utilities.
 
-## Tailwind Architecture (Target)
+## Tailwind Architecture
 
-Use Tailwind with a Vite pipeline and local generated assets.
+Use Tailwind CLI with local generated assets.
 
 ### Build Direction
 
 - Keep `tailwind.css` as source of tokens/utilities/components
-- Compile to `assets/css/style.css` via Vite build output or a Tailwind-only Vite entry
+- Compile `tailwind.css` to `assets/css/style.css` via the npm Tailwind CLI script
 - Remove runtime CDN dependencies from `head.templ`:
   - remove DaisyUI CDN links
   - remove `@tailwindcss/browser` script
@@ -206,8 +206,8 @@ Then recompose domain components (`feed`, `settings`, `subscriptions`, `channel`
 - `internal/templates/layouts/video.templ`
 - `internal/templates/layouts/partials/head.templ`
 - `internal/templates/layouts/partials/navbar.templ`
-- `internal/templates/layouts/partials/footer.templ`
-- `internal/templates/layouts/partials/progress.templ`
+- `internal/templates/components/ui/footer.templ`
+- `internal/templates/components/ui/progress.templ`
 
 Actions:
 
@@ -277,7 +277,7 @@ Actions:
 ## Phase 0: Initial Cleanup and Build Safety
 
 1. Remove runtime style CDN usage in `internal/templates/layouts/partials/head.templ`.
-2. Add local stylesheet link (`/assets/css/style.css` or Vite output equivalent).
+2. Add local stylesheet link (`/assets/css/style.css`).
 3. Add generated CSS to `.gitignore`:
    - `assets/css/style.css`
 4. Untrack generated CSS from git:

--- a/internal/server/routes/api/channels.templ
+++ b/internal/server/routes/api/channels.templ
@@ -8,6 +8,7 @@ import (
 	"github.com/cufee/feedlr-yt/internal/metrics"
 	"github.com/cufee/feedlr-yt/internal/server/handler"
 	"github.com/cufee/feedlr-yt/internal/templates/components/subscriptions"
+	"github.com/cufee/feedlr-yt/internal/templates/components/ui"
 	"github.com/cufee/feedlr-yt/internal/templates/pages"
 	"github.com/cufee/feedlr-yt/internal/types"
 	"github.com/cufee/tpot/brewed"
@@ -45,7 +46,7 @@ var SearchChannels brewed.Partial[*handler.Context] = func(ctx *handler.Context)
 }
 
 templ channelsSearchErrorMessage(message string) {
-	<div class="m-auto text-2xl">{ message }</div>
+	@ui.EmptyState(message, "", "w-full py-6")
 }
 
 var CreateSubscription brewed.Partial[*handler.Context] = func(ctx *handler.Context) (templ.Component, error) {

--- a/internal/templates/components/channel/channel.templ
+++ b/internal/templates/components/channel/channel.templ
@@ -7,7 +7,7 @@ import (
 templ ChannelTile(channel youtube.Channel, actionButton templ.Component) {
 	<div class="ui-channel-tile">
 		<div class="ui-channel-thumb">
-			<img src={ channel.Thumbnail } alt={ channel.Title } onload="this.style.display='block'" onerror="this.style.display='none'"/>
+			<img src={ channel.Thumbnail } alt={ channel.Title } loading="lazy"/>
 			<div class="ui-channel-thumb-skeleton"></div>
 		</div>
 		<div class="flex min-h-[5.3rem] w-full flex-col justify-start">
@@ -17,7 +17,7 @@ templ ChannelTile(channel youtube.Channel, actionButton templ.Component) {
 					@actionButton
 				}
 			</div>
-			<span class="ui-channel-description" style="overflow-wrap: anywhere;">
+			<span class="ui-channel-description">
 				if channel.Description != "" {
 					{ channel.Description }
 				} else {

--- a/internal/templates/components/feed/video.templ
+++ b/internal/templates/components/feed/video.templ
@@ -74,13 +74,13 @@ func VideoCarousel(videos []types.VideoProps, options ...FeedOption) templ.Compo
 }
 
 templ videoCarouselComponent(videos []types.VideoProps, opts feedOptions) {
-	<div class="watch-later-section relative h-44 md:h-52" id="components-video-carousel">
-		<div class="watch-later-items flex w-full h-full gap-3 overflow-x-auto snap-x snap-mandatory" id="watch-later-items">
+	<div class="ui-watch-later-section" id="components-video-carousel">
+		<div class="ui-watch-later-items" id="watch-later-items">
 			for _, video := range videos {
 				@WatchLaterCarouselItem(video)
 			}
 		</div>
-		<div class="watch-later-placeholder absolute inset-0 flex items-center justify-center">
+		<div class="ui-watch-later-placeholder">
 			<span class="ui-feed-time">Refresh to hide this section</span>
 		</div>
 	</div>
@@ -88,7 +88,7 @@ templ videoCarouselComponent(videos []types.VideoProps, opts feedOptions) {
 
 // WatchLaterCarouselItem - a single carousel item for OOB insertion
 templ WatchLaterCarouselItem(video types.VideoProps) {
-	<div class="watch-later-item ui-motion-swap snap-start shrink-0 w-56 md:w-72 flex flex-col" id={ fmt.Sprintf("carousel-item-%s", video.ID) }>
+	<div class="ui-watch-later-item ui-motion-swap" id={ fmt.Sprintf("carousel-item-%s", video.ID) }>
 		<a href={ templ.URL(fmt.Sprintf("/video/%s", video.ID)) } hx-boost="true" hx-target="body" class="relative flex flex-col h-full cursor-pointer group">
 			<div class="ui-video-card aspect-video">
 				@VideoThumbnail(video.ID, video.Title, false)
@@ -235,37 +235,18 @@ templ videoCardComponent(video types.VideoProps, opts feedOptions) {
 				</div>
 			}
 		}
-		<div class={ "ui-video-duration-chip", templ.KV("ui-video-duration-chip-no-progress", !(video.Progress > 0 && opts.showProgressBar)) }>
-			if video.Hidden {
-			} else if video.Type == "live_stream" {
-				<div class="w-2 h-2 bg-red-500 rounded-full"></div> LIVE
-			} else if video.Type == "upcoming_stream" {
-				<div class="w-2 h-2 bg-gray-500 rounded-full"></div> OFFLINE
-			} else {
-				{ secondsToDurationString(video.Duration) }
-			}
+			<div class={ "ui-video-duration-chip", templ.KV("ui-video-duration-chip-no-progress", !(video.Progress > 0 && opts.showProgressBar)) }>
+				if video.Hidden {
+				} else if video.Type == "live_stream" {
+					<div class="ui-video-status-live-dot"></div> LIVE
+				} else if video.Type == "upcoming_stream" {
+					<div class="ui-video-status-offline-dot"></div> OFFLINE
+				} else {
+					{ secondsToDurationString(video.Duration) }
+				}
 		</div>
 		@VideoThumbnail(video.ID, video.Title, video.Hidden)
 	}
-}
-
-templ VideoTile(video types.VideoProps, opts feedOptions) {
-	<div class="relative overflow-hidden video-tile rounded-[var(--radius-media)]">
-		<a href={ templ.URL(fmt.Sprintf("/video/%s", video.ID)) } hx-boost="true" hx-target="body" class="relative group">
-			@videoCardComponent(video, opts)
-		</a>
-	</div>
-}
-
-templ VideoTileWithTitle(video types.VideoProps, opts feedOptions) {
-	<div class="relative overflow-hidden shadow-md group carousel-item rounded-[var(--radius-media)] w-fit" id={ fmt.Sprintf("video-tile-%s", video.ID) }>
-		@VideoTile(video, opts)
-		<div class="pointer-events-none absolute bottom-0 left-0 z-10 flex w-full translate-y-2 flex-col gap-1 bg-black/60 opacity-0 transition-all duration-150 ease-[var(--ease-standard)] md:hidden group-hover:translate-y-0 group-hover:opacity-100">
-			<div class="px-2 py-1 font-bold text-center text-white truncate">
-				{ video.Title }
-			</div>
-		</div>
-	</div>
 }
 
 func secondsToDurationString(seconds int) string {

--- a/internal/templates/components/icons/expand.templ
+++ b/internal/templates/components/icons/expand.templ
@@ -1,6 +1,0 @@
-package icons
-
-templ Expand() {
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path></svg>
-}
-

--- a/internal/templates/components/icons/play.templ
+++ b/internal/templates/components/icons/play.templ
@@ -1,7 +1,0 @@
-package icons
-
-templ Play() {
-	<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4">
-		<path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z"></path>
-	</svg>
-}

--- a/internal/templates/components/settings/account.templ
+++ b/internal/templates/components/settings/account.templ
@@ -4,6 +4,7 @@ package settings
 import (
 	"fmt"
 	"github.com/cufee/feedlr-yt/internal/templates/components/icons"
+	"github.com/cufee/feedlr-yt/internal/templates/components/shared"
 	"github.com/cufee/feedlr-yt/internal/types"
 	"time"
 )
@@ -40,12 +41,21 @@ templ ManageAccount(passkeys []types.PasskeyProps) {
 		</div>
 	</div>
 	<script>
-		document.getElementById('addPasskey').addEventListener('click', register);
+			document.getElementById('addPasskey').addEventListener('click', register);
 
-		function showMessage(message, isError = false) {
-      const errorSpan = document.getElementById('error');
-      if (!isError) {
-        errorSpan.classList.add("hidden");
+			function getWebAuthnBrowser() {
+	      const webAuthnBrowser = window.SimpleWebAuthnBrowser;
+	      if (webAuthnBrowser) {
+	        return webAuthnBrowser;
+	      }
+	      showMessage("Passkey library failed to load. Refresh and try again.", true);
+	      return null;
+			}
+
+			function showMessage(message, isError = false) {
+	      const errorSpan = document.getElementById('error');
+	      if (!isError) {
+	        errorSpan.classList.add("hidden");
         errorSpan.innerText = "";
         return;
       }
@@ -65,12 +75,17 @@ templ ManageAccount(passkeys []types.PasskeyProps) {
 								throw new Error(msg);
 						}
 
-						// Convert the registration options to JSON.
-						const options = await response.json();
+							// Convert the registration options to JSON.
+							const options = await response.json();
 
-						// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
-						// A new attestation is created. This also means a new public-private-key pair is created.
-						const attestationResponse = await SimpleWebAuthnBrowser.startRegistration(options.publicKey);
+							const webAuthnBrowser = getWebAuthnBrowser();
+							if (!webAuthnBrowser) {
+								return;
+							}
+
+							// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
+							// A new attestation is created. This also means a new public-private-key pair is created.
+							const attestationResponse = await webAuthnBrowser.startRegistration(options.publicKey);
 
 						// Send attestationResponse back to server for verification and storage.
 						const verificationResponse = await fetch('/api/passkeys/add/finish', {
@@ -96,5 +111,5 @@ templ ManageAccount(passkeys []types.PasskeyProps) {
 				}
 		}
 	</script>
-	<script src="/assets/js/index.es5.umd.min.js" async></script>
+		@shared.PasskeyBrowserScript()
 }

--- a/internal/templates/components/settings/youtube-sync.templ
+++ b/internal/templates/components/settings/youtube-sync.templ
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"fmt"
+	"github.com/cufee/feedlr-yt/internal/templates/components/ui"
 	"github.com/cufee/feedlr-yt/internal/types"
 	"github.com/cufee/feedlr-yt/internal/utils"
 	"strings"
@@ -82,16 +83,16 @@ templ YouTubeSyncSettings(status types.YouTubeSyncStatusProps, tvStatus types.Yo
 				if !status.Available {
 					<div class="ui-settings-note">Playlist sync is disabled on this deployment.</div>
 				}
-				if status.Available && !status.Connected {
-					<div class="flex flex-col gap-3">
-						<div class="ui-settings-note leading-relaxed">
-							Connect your YouTube account to keep a private playlist mirrored from your Feedlr home feed.
+					if status.Available && !status.Connected {
+						<div class="flex flex-col gap-3">
+							<div class="ui-settings-note leading-relaxed">
+								Connect your YouTube account to keep a private playlist mirrored from your Feedlr home feed.
+							</div>
+							<form action="/api/settings/youtube-sync/connect/begin" method="post">
+								@ui.Button("Connect YouTube", ui.WithButtonVariant(ui.ButtonPrimary), ui.WithButtonSize(ui.ButtonSmall))
+							</form>
 						</div>
-						<form action="/api/settings/youtube-sync/connect/begin" method="post">
-							<button type="submit" class="ui-btn ui-btn-primary ui-btn-sm">Connect YouTube</button>
-						</form>
-					</div>
-				}
+					}
 				if status.Available && status.Connected {
 					<div class="ui-settings-grid">
 						<div class="ui-settings-stat">
@@ -139,12 +140,12 @@ templ YouTubeSyncSettings(status types.YouTubeSyncStatusProps, tvStatus types.Yo
 							<button type="submit" class={ syncToggleButtonClass(status.Enabled) }>
 								{ syncToggleButtonLabel(status.Enabled) }
 							</button>
-						</form>
-						<form action="/api/settings/youtube-sync/disconnect" method="post">
-							<button type="submit" class="ui-btn ui-btn-sm ui-btn-neutral w-32 justify-center border-danger/35 text-red-100 hover:bg-danger/20" hx-confirm="Disconnect YouTube sync? This removes stored credentials.">Disconnect</button>
-						</form>
-					</div>
-				}
+							</form>
+							<form action="/api/settings/youtube-sync/disconnect" method="post">
+								<button type="submit" class="ui-btn ui-btn-sm ui-btn-neutral ui-btn-destructive-neutral w-32 justify-center" hx-confirm="Disconnect YouTube sync? This removes stored credentials.">Disconnect</button>
+							</form>
+						</div>
+					}
 			</div>
 			<div class="ui-settings-divider"></div>
 			<div class="flex flex-col gap-4" id="youtube-tv-sync-settings">
@@ -157,18 +158,18 @@ templ YouTubeSyncSettings(status types.YouTubeSyncStatusProps, tvStatus types.Yo
 				if !tvStatus.Available {
 					<div class="ui-settings-note">TV sync is disabled on this deployment.</div>
 				}
-				if tvStatus.Available && tvStatus.ConnectionState == "" {
-					<form action="/api/settings/youtube-sync/tv/connect" method="post" class="flex flex-col gap-2 md:flex-row md:items-center">
-						<input
-							type="text"
+					if tvStatus.Available && tvStatus.ConnectionState == "" {
+						<form action="/api/settings/youtube-sync/tv/connect" method="post" class="flex flex-col gap-2 md:flex-row md:items-center">
+							<input
+								type="text"
 							name="pairing_code"
 							class="ui-input w-full md:w-64"
-							placeholder="YouTube TV pairing code"
-							required
-						/>
-						<button type="submit" class="ui-btn ui-btn-primary ui-btn-sm w-32 justify-center">Pair TV</button>
-					</form>
-				}
+								placeholder="YouTube TV pairing code"
+								required
+							/>
+							@ui.Button("Pair TV", ui.WithButtonVariant(ui.ButtonPrimary), ui.WithButtonSize(ui.ButtonSmall), ui.WithButtonClass("w-32 justify-center"))
+						</form>
+					}
 				if tvStatus.Available && tvStatus.ConnectionState != "" {
 					<div class="ui-settings-grid">
 						<div class="ui-settings-stat">
@@ -201,12 +202,12 @@ templ YouTubeSyncSettings(status types.YouTubeSyncStatusProps, tvStatus types.Yo
 							<button type="submit" class={ syncToggleButtonClass(tvStatus.Enabled) }>
 								{ syncToggleButtonLabel(tvStatus.Enabled) }
 							</button>
-						</form>
-						<form action="/api/settings/youtube-sync/tv/disconnect" method="post">
-							<button type="submit" class="ui-btn ui-btn-sm ui-btn-neutral w-32 justify-center border-danger/35 text-red-100 hover:bg-danger/20" hx-confirm="Disconnect TV sync? This removes the paired device token.">Disconnect</button>
-						</form>
-					</div>
-				}
+							</form>
+							<form action="/api/settings/youtube-sync/tv/disconnect" method="post">
+								<button type="submit" class="ui-btn ui-btn-sm ui-btn-neutral ui-btn-destructive-neutral w-32 justify-center" hx-confirm="Disconnect TV sync? This removes the paired device token.">Disconnect</button>
+							</form>
+						</div>
+					}
 			</div>
 		</div>
 	</div>

--- a/internal/templates/components/shared/open-video.templ
+++ b/internal/templates/components/shared/open-video.templ
@@ -1,7 +1,5 @@
 package shared
 
-import "fmt"
-
 templ OpenVideoButton() {
 	<div class="flex w-full justify-center pb-0.5">
 		<div class="flex flex-row gap-2">
@@ -36,49 +34,69 @@ templ OpenVideoInput(url string, valid bool) {
         if #open_video_input.value == ''
           halt"
 	>
-		<input
-			type="text"
-			id="open_video_input"
-			name="link"
-			value={ url }
-			placeholder="https://youtube.com/watch..."
-			class={ fmt.Sprintf("ui-input w-full %s", OptionalClass(!valid, "ui-input-error")) }
-		/>
-		<button type="submit" class="ui-btn ui-btn-primary ui-btn-md shrink-0">Watch</button>
-	</form>
-}
+			<input
+				type="text"
+				id="open_video_input"
+				name="link"
+				value={ url }
+				placeholder="https://youtube.com/watch..."
+				class={ "ui-input", "w-full", templ.KV("ui-input-error", !valid) }
+			/>
+			<button type="submit" class="ui-btn ui-btn-primary ui-btn-md shrink-0">Watch</button>
+		</form>
+	}
 
 script openVideoModalScript() {
-	const modal = document.getElementById("open_video_modal");
-	const modalBox = document.getElementById("open_video_modal_box");
-	const modalButton = document.getElementById("open_video_modal_btn");
-	
-	const openVideoFromText = (text) => {
-		if (!text) {
-			return false;
-		}
-		try {
-			const url = new URL(text);
-			let videoId;
-			if (url.hostname.endsWith('youtube.com')) {
-                videoId = url.searchParams.get('v');
-            } else if (url.hostname === 'youtu.be') {
-                videoId = url.pathname.slice(1);
-			} else if (url.hostname === 'feedlr.app' && url.pathname.includes("/video/")) {
-                videoId = url.pathname.split("/video/").pop();
-            }
-			if (!videoId) {
-				throw "no video id found in clipboard";
+		const modal = document.getElementById("open_video_modal");
+		const modalBox = document.getElementById("open_video_modal_box");
+		const modalButton = document.getElementById("open_video_modal_btn");
+
+		const extractVideoID = (text) => {
+			if (!text) {
+				return "";
 			}
-			window.location.href = "/video/" + videoId;
-			return true;
-		} catch (_error) {
-			return false;
+			try {
+				const parsed = new URL(text);
+				let videoID = parsed.searchParams.get("v") || "";
+				if (!videoID && parsed.pathname) {
+					const parts = parsed.pathname.split("/").filter(Boolean);
+					videoID = parts[parts.length - 1] || "";
+				}
+				videoID = videoID.trim();
+				if (!/^[a-zA-Z0-9_-]{5,}$/.test(videoID)) {
+					return "";
+				}
+				return videoID;
+			} catch (_error) {
+				return "";
+			}
 		}
-	}
-	
-	const openModal = async () => {
-		try {
+		
+		const openVideoFromText = (text) => {
+			const videoID = extractVideoID(text);
+			if (!videoID) {
+				return false;
+			}
+			window.location.href = "/video/" + videoID;
+			return true;
+		}
+
+		const shouldIgnoreEnterHotkey = (event) => {
+			if (event.defaultPrevented || event.repeat || event.metaKey || event.ctrlKey || event.altKey) {
+				return true;
+			}
+			const target = event.target;
+			if (!(target instanceof HTMLElement)) {
+				return false;
+			}
+			if (target.isContentEditable) {
+				return true;
+			}
+			return target.closest("input, textarea, select, button, a, [role='button']") !== null;
+		}
+		
+		const openModal = async () => {
+			try {
 			const text = await navigator.clipboard.readText();
 			if (!openVideoFromText(text)) {
 				throw "failed to open a video from clipboard";
@@ -94,16 +112,15 @@ script openVideoModalScript() {
 
 	// support manually clicking on the button
 	modalButton.addEventListener("click", openModal);
-	modal.addEventListener("click", (e) => {
-		if (e.target === modal) {
-			modal.close();
-		}
-	});
-  	document.addEventListener("keydown", (e) => {
-		if (e.key === "Enter") {
-			if (!modal.open) {
-				openModal();
+		modal.addEventListener("click", (e) => {
+			if (e.target === modal) {
+				modal.close();
 			}
-		}
-	});
-}
+		});
+	  	document.addEventListener("keydown", (e) => {
+			if (e.key !== "Enter" || modal.open || shouldIgnoreEnterHotkey(e)) {
+				return;
+			}
+			openModal();
+		});
+	}

--- a/internal/templates/components/shared/optional-class.go
+++ b/internal/templates/components/shared/optional-class.go
@@ -1,8 +1,0 @@
-package shared
-
-func OptionalClass(condition bool, class string) string {
-	if condition {
-		return class
-	}
-	return ""
-}

--- a/internal/templates/components/shared/passkey.templ
+++ b/internal/templates/components/shared/passkey.templ
@@ -1,0 +1,5 @@
+package shared
+
+templ PasskeyBrowserScript() {
+	<script src="https://cdn.jsdelivr.net/npm/@simplewebauthn/browser@13.2.2/dist/bundle/index.umd.min.js"></script>
+}

--- a/internal/templates/components/shared/search.templ
+++ b/internal/templates/components/shared/search.templ
@@ -5,58 +5,115 @@ import "fmt"
 templ FuseSearch(id string, label string, minLength int) {
 	<div class="flex items-center justify-center w-full" id={ fmt.Sprintf("fuse-search-%s", id) }>
 		<input id={ fmt.Sprintf("search-input-%s", id) } type="text" placeholder={ label } class="ui-input w-full text-center"/>
-		<script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2" onload={ fuseSearch(fmt.Sprintf("search-input-%s", id), id, id, minLength) }></script>
 	</div>
+	@EmbedScript(fuseSearch(fmt.Sprintf("search-input-%s", id), id, id, minLength), fmt.Sprintf("search-input-%s", id), id, id, minLength)
 }
 
 script fuseSearch(searchInputId, targetId, parentId string, minLength int) {
-	const displayresults = (target, items) => {
-		if (parentId == targetId) {
-			for (const n of target.children) {
-				if (!items.includes(n.dataset.search)) {
-					n.classList.add("hidden")
-				} else {
-					n.classList.remove("hidden")
-				}
-			}
-		} else {
-			target.innerHTML = ""
-			for (const item of result) {
-				target.appendChild(item.item)
-			}
+	const ensureFuseLoaded = () => {
+		if (window.Fuse) {
+			return Promise.resolve(window.Fuse);
 		}
+		if (window.__feedlrFusePromise) {
+			return window.__feedlrFusePromise;
+		}
+		window.__feedlrFusePromise = new Promise((resolve, reject) => {
+			const script = document.createElement("script");
+			script.src = "https://cdn.jsdelivr.net/npm/fuse.js@6.6.2";
+			script.async = true;
+			script.onload = () => {
+				if (window.Fuse) {
+					resolve(window.Fuse);
+					return;
+				}
+				reject(new Error("Fuse loaded without global export"));
+			};
+			script.onerror = () => reject(new Error("Failed to load Fuse.js"));
+			document.head.appendChild(script);
+		});
+		return window.__feedlrFusePromise;
 	}
 
 	const initSearch = () => {
-		const target = document.getElementById(targetId)
-		const container = document.getElementById(parentId)
-		const input = document.getElementById(searchInputId)
-		const items = [...container.children].map(n => n.dataset.search)
-		const options = { includeScore: false }
+		const target = document.getElementById(targetId);
+		const container = document.getElementById(parentId);
+		const input = document.getElementById(searchInputId);
+		if (!target || !container || !input || input.dataset.fuseInit === "true") {
+			return false;
+		}
+		input.dataset.fuseInit = "true";
 
-		const fuse = new Fuse(items, options)
-		const search = (query) => {
-			if (query.length == 0) {
-				input.classList.remove("ui-input-error")
-				displayresults(target, items)
-				return
-			} else if (query.length >= minLength)  {
-				input.classList.remove("ui-input-error")
-			} else if (query.length < minLength) {
-				input.classList.add("ui-input-error")
-				return
+		ensureFuseLoaded().then((Fuse) => {
+			const entries = [...container.children]
+				.filter((node) => node.dataset.search)
+				.map((node) => ({ key: node.dataset.search, node: node }));
+			const searchableKeys = entries.map((entry) => entry.key);
+			const fuse = new Fuse(entries, {
+				includeScore: false,
+				ignoreLocation: true,
+				keys: ["key"],
+			});
+
+			const displayResults = (keys) => {
+				const visible = new Set(keys);
+				if (parentId == targetId) {
+					for (const node of container.children) {
+						if (!node.dataset.search) {
+							continue;
+						}
+						if (!visible.has(node.dataset.search)) {
+							node.classList.add("hidden");
+							continue;
+						}
+						node.classList.remove("hidden");
+					}
+					return;
+				}
+
+				target.innerHTML = "";
+				for (const entry of entries) {
+					if (!visible.has(entry.key)) {
+						continue;
+					}
+					target.appendChild(entry.node.cloneNode(true));
+				}
+				window.htmx?.process(target);
 			}
 
-			const result = fuse.search(query.length > 1 ? `'"${query}"` : "'"+query)
-			displayresults(target, result.map(i => i.item))
-		}
-		
-		input.addEventListener("input", (e) => {
-			search(e.target.value)
-		})
+			const runSearch = (query) => {
+				const value = query.trim();
+				if (value.length === 0) {
+					input.classList.remove("ui-input-error");
+					displayResults(searchableKeys);
+					return;
+				}
+				if (value.length < minLength) {
+					input.classList.add("ui-input-error");
+					return;
+				}
+				input.classList.remove("ui-input-error");
+				const matches = fuse.search(value).map((result) => result.item.key);
+				displayResults(matches);
+			}
+
+			input.addEventListener("input", (event) => {
+				runSearch(event.target.value || "");
+			});
+			runSearch(input.value || "");
+		}).catch(() => {
+			input.classList.add("ui-input-error");
+		});
+
+		return true;
 	}
 
-	const waitForParent = setTimeout(() => {
-		document.getElementById(parentId) && initSearch() && clearTimeout(waitForParent)
-	}, 100)
+	if (initSearch()) {
+		return;
+	}
+	const observer = new MutationObserver(() => {
+		if (initSearch()) {
+			observer.disconnect();
+		}
+	});
+	observer.observe(document.body, { childList: true, subtree: true });
 }

--- a/internal/templates/components/shared/textbox.templ
+++ b/internal/templates/components/shared/textbox.templ
@@ -1,7 +1,7 @@
 package shared
 
 templ Textbox(class string) {
-  <span class={ "overflow-hidden truncate whitespace-normal " + class } style="overflow-wrap: anywhere;">
+  <span class={ "ui-overflow-anywhere overflow-hidden truncate whitespace-normal " + class }>
     { children... }
   </span>
 }

--- a/internal/templates/components/subscriptions/search.templ
+++ b/internal/templates/components/subscriptions/search.templ
@@ -9,7 +9,7 @@ import (
 templ SearchChannels() {
 	<div id="search" class="ui-search-shell">
 		<div class="ui-search-box group" id="search-box">
-			<input type="search" placeholder="Enter Channel Name" name="search" minlength="5" maxlength="64" _="on clear send clear to #search-results on load set my value to '' then" class="ui-input w-full" hx-get="/api/channels/search" hx-target="#search-results" hx-swap="innerHTML" hx-trigger="keyup changed delay:750ms" hx-sync="this:replace" id="search-input"/>
+			<input type="search" placeholder="Enter Channel Name" name="search" minlength="3" maxlength="32" _="on clear send clear to #search-results on load set my value to '' then" class="ui-input w-full" hx-get="/api/channels/search" hx-target="#search-results" hx-swap="innerHTML" hx-trigger="keyup changed delay:750ms" hx-sync="this:replace" id="search-input"/>
 		</div>
 		<div id="search-results" class="ui-search-results empty:hidden"></div>
 	</div>

--- a/internal/templates/components/ui/dialog.templ
+++ b/internal/templates/components/ui/dialog.templ
@@ -30,10 +30,3 @@ templ dialogImpl(id string, opts dialogOptions) {
 		</div>
 	</dialog>
 }
-
-templ DialogBackdropButton(label string) {
-	<form method="dialog" class="ui-dialog-backdrop">
-		<button>{ label }</button>
-	</form>
-}
-

--- a/internal/templates/components/ui/input.templ
+++ b/internal/templates/components/ui/input.templ
@@ -1,5 +1,7 @@
 package ui
 
+import "strconv"
+
 type InputVariant string
 
 const (
@@ -8,11 +10,14 @@ const (
 )
 
 type inputOptions struct {
-	inputType   string
-	variant     InputVariant
-	class       string
-	disabled    bool
+	inputType    string
+	variant      InputVariant
+	class        string
+	disabled     bool
 	autocomplete string
+	minLength    string
+	maxLength    string
+	required     bool
 }
 
 type InputOption func(*inputOptions)
@@ -33,7 +38,17 @@ func WithInputAutocomplete(value string) InputOption {
 	return func(o *inputOptions) { o.autocomplete = value }
 }
 
+func WithInputMinLength(value int) InputOption {
+	return func(o *inputOptions) { o.minLength = strconv.Itoa(value) }
+}
+
+func WithInputMaxLength(value int) InputOption {
+	return func(o *inputOptions) { o.maxLength = strconv.Itoa(value) }
+}
+
 var InputDisabled InputOption = func(o *inputOptions) { o.disabled = true }
+
+var InputRequired InputOption = func(o *inputOptions) { o.required = true }
 
 func Input(id, name, value, placeholder string, opts ...InputOption) templ.Component {
 	o := inputOptions{
@@ -76,6 +91,12 @@ templ inputImpl(id, name, value, placeholder string, opts inputOptions) {
 		class={ inputClass(opts) }
 		disabled?={ opts.disabled }
 		autocomplete={ opts.autocomplete }
+		if opts.minLength != "" {
+			minlength={ opts.minLength }
+		}
+		if opts.maxLength != "" {
+			maxlength={ opts.maxLength }
+		}
+		required?={ opts.required }
 	/>
 }
-

--- a/internal/templates/components/ui/progress.templ
+++ b/internal/templates/components/ui/progress.templ
@@ -4,7 +4,7 @@ import "github.com/cufee/feedlr-yt/internal/templates/components/shared"
 
 templ NavProgress() {
 	<div class="fixed top-0 z-40 w-full overflow-hidden h-fit">
-		<div id="nav-progress" class="invisible h-1 rounded-r-full bg-accent transition-all duration-[50ms] ease-[var(--ease-standard)]" style="width: 0%"></div>
+		<div id="nav-progress" class="invisible h-1 w-0 rounded-r-full bg-accent transition-all duration-[50ms] ease-[var(--ease-standard)]"></div>
 	</div>
 	@shared.EmbedScript(animateNavProgress())
 }

--- a/internal/templates/components/ui/tabs.templ
+++ b/internal/templates/components/ui/tabs.templ
@@ -23,11 +23,3 @@ templ tabsImpl(opts tabsOptions) {
 		{ children... }
 	</div>
 }
-
-templ TabButton(label string, active bool, class string) {
-	<button class={ joinClasses("ui-tab", ifClass(active, "ui-tab-active"), class) }>
-		{ label }
-		{ children... }
-	</button>
-}
-

--- a/internal/templates/components/ui/toggle.templ
+++ b/internal/templates/components/ui/toggle.templ
@@ -31,11 +31,3 @@ templ toggleImpl(id, name string, checked bool, opts toggleOptions) {
 		disabled?={ opts.disabled }
 	/>
 }
-
-templ ToggleWithLabel(id, name, label string, checked bool, opts ...ToggleOption) {
-	<label class="inline-flex items-center gap-2 cursor-pointer">
-		@Toggle(id, name, checked, opts...)
-		<span class="text-sm text-text-secondary">{ label }</span>
-	</label>
-}
-

--- a/internal/templates/layouts/app.templ
+++ b/internal/templates/layouts/app.templ
@@ -15,7 +15,7 @@ templ app(path string, authenticated bool, content ...templ.Component) {
 	<html lang="en" data-theme="dim">
 		@partials.Head(false, partials.AppManifest(), partials.GenericOgMetadata())
 		<body class="min-h-dvh flex flex-col" hx-ext="head-support">
-			@partials.NavProgressAnimated()
+			@ui.NavProgress()
 			@ui.PageShellMain("gap-3 py-2") {
 				@partials.Navbar(path, authenticated)
 				for _, c := range content {
@@ -24,7 +24,7 @@ templ app(path string, authenticated bool, content ...templ.Component) {
 				{ children... }
 			}
 			@ui.PageShellFooter("") {
-				@partials.Footer()
+				@ui.Footer()
 			}
 		</body>
 	</html>

--- a/internal/templates/layouts/main.templ
+++ b/internal/templates/layouts/main.templ
@@ -16,39 +16,35 @@ var Legal brewed.Layout[*handler.Context] = func(ctx *handler.Context, body ...t
 }
 
 templ main(content ...templ.Component) {
-	<html lang="en" data-theme="dim">
-		@partials.Head(false, partials.AppManifest(), partials.GenericOgMetadata())
-		<body class="min-h-dvh flex flex-col" hx-ext="head-support">
-			@partials.NavProgressAnimated()
-			@ui.PageShellMain("py-3") {
-				for _, c := range content {
-					@c
-				}
-				{ children... }
-			}
-			@ui.PageShellFooter("") {
-				@partials.Footer()
-			}
-		</body>
-	</html>
+	@pageShell("py-3", nil, content...)
 }
 
 templ legal(content ...templ.Component) {
+	@pageShell("gap-3 py-2", legalNav(), content...)
+}
+
+templ legalNav() {
+	<div class="pt-2">
+		@ui.NavbarLogoOnly("/")
+	</div>
+}
+
+templ pageShell(mainClass string, nav templ.Component, content ...templ.Component) {
 	<html lang="en" data-theme="dim">
 		@partials.Head(false, partials.AppManifest(), partials.GenericOgMetadata())
 		<body class="min-h-dvh flex flex-col" hx-ext="head-support">
-			@partials.NavProgressAnimated()
-			@ui.PageShellMain("gap-3 py-2") {
-				<div class="pt-2">
-					@ui.NavbarLogoOnly("/")
-				</div>
+			@ui.NavProgress()
+			@ui.PageShellMain(mainClass) {
+				if nav != nil {
+					@nav
+				}
 				for _, c := range content {
 					@c
 				}
 				{ children... }
 			}
 			@ui.PageShellFooter("") {
-				@partials.Footer()
+				@ui.Footer()
 			}
 		</body>
 	</html>

--- a/internal/templates/layouts/partials/footer.templ
+++ b/internal/templates/layouts/partials/footer.templ
@@ -1,7 +1,0 @@
-package partials
-
-import "github.com/cufee/feedlr-yt/internal/templates/components/ui"
-
-templ Footer(...templ.Component) {
-	@ui.Footer()
-}

--- a/internal/templates/layouts/partials/head.templ
+++ b/internal/templates/layouts/partials/head.templ
@@ -27,15 +27,12 @@ templ Head(htmxReplace bool, content ...templ.Component) {
 		<meta charset="UTF-8"/>
 		<meta name="color-scheme" content="dark"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content"/>
-		for _, c := range content {
-			@c
-		}
-		{ children... }
-		<link href="/assets/css/style.css" rel="stylesheet"/>
-		<style>
-			.watch-later-section:has(.watch-later-item) .watch-later-placeholder { display: none; }
-		</style>
-		<script src="/assets/js/htmx.min.js"></script>
-		<script src="/assets/js/hyperscript.min.js" async></script>
-	</head>
+			for _, c := range content {
+				@c
+			}
+			{ children... }
+			<link href="/assets/css/style.css" rel="stylesheet"/>
+			<script src="/assets/js/htmx.min.js"></script>
+			<script src="/assets/js/hyperscript.min.js" async></script>
+		</head>
 }

--- a/internal/templates/layouts/partials/progress.templ
+++ b/internal/templates/layouts/partials/progress.templ
@@ -1,7 +1,0 @@
-package partials
-
-import "github.com/cufee/feedlr-yt/internal/templates/components/ui"
-
-templ NavProgressAnimated(...templ.Component) {
-	@ui.NavProgress()
-}

--- a/internal/templates/layouts/partials/scripts.templ
+++ b/internal/templates/layouts/partials/scripts.templ
@@ -1,5 +1,0 @@
-package partials
-
-templ Scripts(...templ.Component) {
-	
-}

--- a/internal/templates/layouts/video.templ
+++ b/internal/templates/layouts/video.templ
@@ -53,7 +53,7 @@ templ videoLayout(video types.VideoProps, content ...templ.Component) {
 			<meta name="twitter:image:alt" content={ video.Title }/>
 		}
 		<body class="h-svh bg-black" hx-ext="head-support">
-			@partials.NavProgressAnimated()
+			@ui.NavProgress()
 			@ui.PageShellVideo("") {
 				for _, c := range content {
 					@c

--- a/internal/templates/pages/app/index.templ
+++ b/internal/templates/pages/app/index.templ
@@ -25,15 +25,6 @@ templ VideosFeed(props types.UserVideoFeedProps) {
 		if len(props.New) > 0 && len(props.Watched) > 0 {
 			<div class="ui-feed-divider"><span>watched</span></div>
 		}
-		@feed.VideoFeed(props.Watched, "/app", feed.WithChannelName, feed.WithProgressActions, feed.WithProgressBar, feed.WithProgressOverlay)
-	</div>
-}
-
-script tilesScrollOnHover() {
-	var tiles = document.querySelectorAll(".video-tile");
-	tiles.forEach((tile) => {
-		tile.addEventListener("mouseenter", () => {
-			tile.scrollIntoView({ block: 'nearest', behavior: "smooth" });
-		});
-	});
+			@feed.VideoFeed(props.Watched, "/app", feed.WithChannelName, feed.WithProgressActions, feed.WithProgressBar, feed.WithProgressOverlay)
+		</div>
 }

--- a/internal/templates/pages/error.templ
+++ b/internal/templates/pages/error.templ
@@ -31,14 +31,10 @@ templ Error(message string) {
 			<div class="flex items-start text-sm text-red-100/90">
 				<span>{ message }</span>
 			</div>
+			</div>
+			<div class="flex flex-wrap items-center justify-center gap-2">
+				<a href="/" class="ui-btn ui-btn-primary">Home</a>
+				<a href="https://github.com/Cufee/feedlr-yt/issues" class="ui-btn ui-btn-neutral">Submit an Issue</a>
+			</div>
 		</div>
-		<div class="flex flex-wrap items-center justify-center gap-2">
-			<a href="/">
-				<button class="ui-btn ui-btn-primary">Home</button>
-			</a>
-			<a href="https://github.com/Cufee/feedlr-yt/issues">
-				<button class="ui-btn ui-btn-neutral">Submit an Issue</button>
-			</a>
-		</div>
-	</div>
-}
+	}

--- a/internal/templates/pages/landing.templ
+++ b/internal/templates/pages/landing.templ
@@ -9,8 +9,8 @@ templ Landing() {
 			<span class="text-base leading-relaxed text-text-secondary md:text-lg">Feedlr.app offers a refreshing open-source solution for managing your YouTube subscriptions. This free platform is designed to provide an uninterrupted viewing experience, completely free from distracting elements and bothersome advertisements.</span>
 		</div>
 		<div class="flex flex-col items-center justify-center gap-2 sm:flex-row">
-			<a href="/app"><button class="ui-btn ui-btn-primary">Start Watching</button></a>
-			<a href="https://github.com/Cufee/feedlr-yt"><button class="ui-btn ui-btn-neutral">GitHub</button></a>
+			<a href="/app" class="ui-btn ui-btn-primary">Start Watching</a>
+			<a href="https://github.com/Cufee/feedlr-yt" class="ui-btn ui-btn-neutral">GitHub</a>
 		</div>
 	</div>
 }

--- a/internal/templates/pages/login.templ
+++ b/internal/templates/pages/login.templ
@@ -1,23 +1,36 @@
 package pages
 
-import "github.com/cufee/feedlr-yt/internal/templates/components/shared"
+import (
+	"github.com/cufee/feedlr-yt/internal/templates/components/shared"
+	"github.com/cufee/feedlr-yt/internal/templates/components/ui"
+)
 
 templ Login() {
-	<div class="mx-auto my-auto flex w-full max-w-md flex-col items-center justify-center gap-4 px-3 text-center" id="landing">
-		<a href="/">
-			@shared.Logo("text-2xl")
-		</a>
-		<div class="ui-card flex w-full flex-col gap-3">
-			<div class="text-sm text-text-secondary">
-				We use passkeys exclusively.
-			</div>
-			<div>
-				<input id="username" minlength="3" maxlength="24" type="text" class="ui-input w-full" placeholder="Username"/>
-			</div>
-			<div class="flex flex-row flex-wrap gap-2">
-				<button id="loginButton" type="button" class="ui-btn ui-btn-primary grow basis-1/3">Login</button>
-				<button id="registerButton" type="button" class="ui-btn ui-btn-neutral grow basis-1/3">Register</button>
-			</div>
+		<div class="mx-auto my-auto flex w-full max-w-md flex-col items-center justify-center gap-4 px-3 text-center" id="landing">
+			<a href="/">
+				@shared.Logo("text-2xl")
+			</a>
+			<div class="ui-card flex w-full flex-col gap-3">
+				<div class="text-sm text-text-secondary">
+					We use passkeys exclusively.
+				</div>
+				<div>
+					@ui.Input(
+						"username",
+						"username",
+						"",
+						"Username",
+						ui.WithInputClass("w-full"),
+						ui.WithInputAutocomplete("username"),
+						ui.WithInputType("text"),
+						ui.WithInputMinLength(3),
+						ui.WithInputMaxLength(24),
+					)
+				</div>
+				<div class="flex flex-row flex-wrap gap-2">
+					<button id="loginButton" type="button" class="ui-btn ui-btn-primary grow basis-1/3">Login</button>
+					<button id="registerButton" type="button" class="ui-btn ui-btn-neutral grow basis-1/3">Register</button>
+				</div>
 			<div id="error" class="invisible w-full">
 				<div class="ui-toast ui-toast-danger w-full opacity-95">
 					<span></span>
@@ -31,15 +44,24 @@ templ Login() {
 		document.getElementById('username').addEventListener('keyup', (e) => {
           if (e.keyCode === 13 && e.target.value?.length > 3) login();
 		});
-		document.getElementById('username').addEventListener('input', (e) => {
-		  document.getElementById('error').classList.add("invisible")
-		});
+			document.getElementById('username').addEventListener('input', (e) => {
+			  document.getElementById('error').classList.add("invisible")
+			});
 
-		function showMessage(message, isError = false) {
-				const alert = document.getElementById('error');
-				alert.querySelector("span").innerText = message
-				alert.classList.remove("invisible")
-		}
+			function getWebAuthnBrowser() {
+					const webAuthnBrowser = window.SimpleWebAuthnBrowser;
+					if (webAuthnBrowser) {
+							return webAuthnBrowser;
+					}
+					showMessage('Passkey library failed to load. Refresh and try again.', true);
+					return null;
+			}
+
+			function showMessage(message, isError = false) {
+					const alert = document.getElementById('error');
+					alert.querySelector("span").innerText = message
+					alert.classList.remove("invisible")
+			}
 
 		async function register() {
 				// Retrieve the username from the input field
@@ -58,12 +80,17 @@ templ Login() {
 								throw new Error(msg|| 'Failed to get registration options from server');
 						}
 
-						// Convert the registration options to JSON.
-						const options = await response.json();
+							// Convert the registration options to JSON.
+							const options = await response.json();
 
-						// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
-						// A new attestation is created. This also means a new public-private-key pair is created.
-						const attestationResponse = await SimpleWebAuthnBrowser.startRegistration(options.publicKey);
+							const webAuthnBrowser = getWebAuthnBrowser();
+							if (!webAuthnBrowser) {
+									return;
+							}
+
+							// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
+							// A new attestation is created. This also means a new public-private-key pair is created.
+							const attestationResponse = await webAuthnBrowser.startRegistration(options.publicKey);
 
 						// Send attestationResponse back to server for verification and storage.
 						const verificationResponse = await fetch('/register/finish', {
@@ -104,12 +131,17 @@ templ Login() {
 								const msg = await response.text();
 								throw new Error(msg || 'Failed to get login options from server');
 						}
-						// Convert the login options to JSON.
-						const options = await response.json();
+							// Convert the login options to JSON.
+							const options = await response.json();
 
-						// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
-						// A new assertionResponse is created. This also means that the challenge has been signed.
-						const assertionResponse = await SimpleWebAuthnBrowser.startAuthentication(options.publicKey);
+							const webAuthnBrowser = getWebAuthnBrowser();
+							if (!webAuthnBrowser) {
+									return;
+							}
+
+							// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
+							// A new assertionResponse is created. This also means that the challenge has been signed.
+							const assertionResponse = await webAuthnBrowser.startAuthentication(options.publicKey);
 
 						// Send assertionResponse back to server for verification.
 						const verificationResponse = await fetch('/login/finish', {
@@ -132,6 +164,6 @@ templ Login() {
 						showMessage('Error: ' + error.message, true);
 				}
 		}
-	</script>
-	<script src="https://unpkg.com/@simplewebauthn/browser/dist/bundle/index.umd.min.js"></script>
-}
+		</script>
+		@shared.PasskeyBrowserScript()
+	}

--- a/internal/templates/pages/video.templ
+++ b/internal/templates/pages/video.templ
@@ -67,14 +67,6 @@ templ buttonShare(id string) {
 	@shared.EmbedScript(shareButtonScript(id), id)
 }
 
-templ buttonViewOnYoutube(id string) {
-	<a href={ templ.URL("https://youtube.com/watch?from=feedler.app&v=" + id) } target="_blank" id="view-on-youtube" class="ui-video-rail-btn">
-		<div class="border border-glass-stroke/30 rounded-lg px-1.5 py-0.5 pl-2">
-			@icons.Play()
-		</div>
-	</a>
-}
-
 script shareButtonScript(id string) {
 	const link = window.location.origin + "/video/" + id
 	document.getElementById("share-video-link-btn").addEventListener("click", () => {

--- a/tailwind.css
+++ b/tailwind.css
@@ -202,10 +202,6 @@
         @apply mx-auto my-6 w-[min(92vw,36rem)] rounded-[var(--radius-panel)] border border-glass-stroke/25 bg-glass-fill/45 p-5 shadow-[0_10px_36px_-20px_var(--color-glass-shadow)] backdrop-blur-[var(--blur-glass-md)] transition-all duration-200 ease-[var(--ease-emphasized)] motion-reduce:transition-none;
     }
 
-    .ui-dialog-backdrop {
-        @apply hidden;
-    }
-
     .ui-toast {
         @apply rounded-[var(--radius-md)] border px-3 py-2 text-sm shadow-lg backdrop-blur-[var(--blur-glass-sm)] transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
     }
@@ -313,7 +309,7 @@
     }
 
     .ui-channel-thumb img {
-        @apply relative z-10 hidden h-full w-full object-cover transition-all duration-500 ease-[var(--ease-standard)] group-hover:scale-110;
+        @apply relative z-10 h-full w-full object-cover transition-all duration-500 ease-[var(--ease-standard)] group-hover:scale-110;
     }
 
     .ui-channel-thumb-skeleton {
@@ -326,6 +322,7 @@
 
     .ui-channel-description {
         @apply mt-1 text-sm text-text-secondary line-clamp-2;
+        overflow-wrap: anywhere;
     }
 
     .ui-channel-action-btn {
@@ -367,6 +364,26 @@
 
     .ui-search-results {
         @apply flex w-full flex-row flex-wrap gap-3;
+    }
+
+    .ui-watch-later-section {
+        @apply relative h-44 md:h-52;
+    }
+
+    .ui-watch-later-items {
+        @apply flex h-full w-full gap-3 overflow-x-auto snap-x snap-mandatory;
+    }
+
+    .ui-watch-later-item {
+        @apply snap-start shrink-0 w-56 md:w-72 flex flex-col;
+    }
+
+    .ui-watch-later-placeholder {
+        @apply absolute inset-0 flex items-center justify-center;
+    }
+
+    .ui-watch-later-section:has(.ui-watch-later-item) .ui-watch-later-placeholder {
+        display: none;
     }
 
     .ui-settings-section {
@@ -446,6 +463,10 @@
         @apply rounded-[var(--radius-control-compact)] border border-danger/35 bg-danger/15 px-2 py-1 text-xs text-red-100;
     }
 
+    .ui-overflow-anywhere {
+        overflow-wrap: anywhere;
+    }
+
     .ui-spinner {
         @apply inline-block shrink-0 animate-spin rounded-full border-2 border-glass-stroke/35 border-t-accent/80 motion-reduce:animate-none;
     }
@@ -519,6 +540,14 @@
         bottom: calc(var(--space-video-inset-y) + 0.06rem);
     }
 
+    .ui-video-status-live-dot {
+        @apply h-2 w-2 rounded-full bg-danger;
+    }
+
+    .ui-video-status-offline-dot {
+        @apply h-2 w-2 rounded-full bg-text-secondary/55;
+    }
+
     .ui-video-progress-track {
         @apply absolute z-20 overflow-hidden border border-glass-stroke/20 bg-glass-fill/17 shadow-[inset_0_1px_3px_rgba(255,255,255,0.12)] backdrop-blur-md;
         left: var(--space-video-inset-x);
@@ -542,6 +571,10 @@
 
     .ui-video-rail-btn {
         @apply inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius-control-compact)] border border-glass-stroke/18 bg-glass-fill/22 p-0 text-text-secondary transition-all duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/35 hover:text-text-primary active:bg-glass-fill/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.8];
+    }
+
+    .ui-btn-destructive-neutral {
+        @apply border-danger/35 text-red-100 hover:bg-danger/20;
     }
 
     .ui-motion-swap {


### PR DESCRIPTION
## Summary
- clean up frontend loose ends from the recent redesign pass
- fix passkey script loading consistency and add runtime guards
- align search validation/empty-state behavior with backend rules
- remove dead template/components and simplify layout shell wrappers
- harden open-video parsing + keyboard behavior and improve shared Fuse search init
- sync frontend/redesign docs with current Tailwind CLI and component structure

## Validation
- go test ./internal/server/... ./internal/templates/...
- npm run build

## Notes
- removed the temporary working cleanup doc as requested