### PR TITLE
Route all YouTube traffic through proxies

### DIFF
--- a/internal/api/youtube/auth/login.go
+++ b/internal/api/youtube/auth/login.go
@@ -19,18 +19,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewClient(store database.ConfigurationClient) *Client {
+func NewClient(store database.ConfigurationClient) (*Client, error) {
 	httpClient, err := netproxy.NewYouTubeHTTPClient(0)
 	if err != nil {
-		log.Warn().Err(err).Msg("failed to initialize youtube proxy transport, falling back to default http client")
-		httpClient = http.DefaultClient
+		return nil, errors.Wrap(err, "failed to initialize youtube proxy transport")
 	}
 
 	return &Client{
 		http:   httpClient,
 		authMx: &sync.Mutex{},
 		store:  store,
-	}
+	}, nil
 }
 
 func (c *Client) Close() error {

--- a/internal/api/youtube/auth/login_test.go
+++ b/internal/api/youtube/auth/login_test.go
@@ -10,7 +10,10 @@ import (
 )
 
 func testAuthClient() (*Client, error) {
-	client := NewClient(&mock.AuthStore{})
+	client, err := NewClient(&mock.AuthStore{})
+	if err != nil {
+		return nil, err
+	}
 	authed, err := client.Authenticate(context.Background(), true)
 	if err != nil {
 		return nil, err

--- a/internal/api/youtube/client.go
+++ b/internal/api/youtube/client.go
@@ -45,8 +45,11 @@ func NewClient(apiKey string, auth *auth.Client) (*client, error) {
 	}
 
 	c := &client{auth: auth, http: httpClient}
-	opts := option.WithAPIKey(apiKey)
-	service, err := youtube.NewService(context.Background(), opts)
+	service, err := youtube.NewService(
+		context.Background(),
+		option.WithAPIKey(apiKey),
+		option.WithHTTPClient(httpClient),
+	)
 	metrics.ObserveYouTubeAPICall("data_v3", "new_service", err)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -49,7 +49,10 @@ func main() {
 	}
 	logic.DefaultYouTubeTVSync = youtubeTVSync
 
-	authClient := auth.NewClient(db)
+	authClient, err := auth.NewClient(db)
+	if err != nil {
+		panic(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	done, err := authClient.Authenticate(ctx, os.Getenv("YOUTUBE_API_SKIP_AUTH_CACHE") == "true")
 	if err != nil {

--- a/main_dev.go
+++ b/main_dev.go
@@ -40,7 +40,10 @@ func main() {
 	logic.DefaultYouTubeTVSync = youtubeTVSync
 
 	// YouTube API setup
-	authClient := auth.NewClient(db)
+	authClient, err := auth.NewClient(db)
+	if err != nil {
+		panic(err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
 	done, err := authClient.Authenticate(ctx, os.Getenv("YOUTUBE_API_SKIP_AUTH_CACHE") == "true")
 	if err != nil {


### PR DESCRIPTION
## Summary
- route YouTube Data API v3 client through the proxy-aware HTTP client
- remove auth client fallback to direct `http.DefaultClient` when proxy transport init fails
- make startup fail fast if proxy transport initialization fails
- route YouTube playlist sync OAuth exchange and token refresh/service calls through proxy-aware HTTP context

## Validation
- `go test ./internal/api/youtube/auth ./internal/api/youtube ./internal/logic -run '^$'`
