### PR TITLE
Improve scroll performance

### DIFF
--- a/internal/templates/components/channel/channel.templ
+++ b/internal/templates/components/channel/channel.templ
@@ -2,7 +2,6 @@ package channel
 
 import (
 	"fmt"
-
 	"github.com/cufee/feedlr-yt/internal/api/youtube"
 )
 
@@ -20,7 +19,7 @@ templ ChannelTile(channel youtube.Channel, thumbnailURL string, actionButton tem
 				onerror="this.remove()"
 				src={ thumbnailURL }
 				alt={ channel.Title }
-				loading="eager"
+				loading="lazy"
 				decoding="async"
 			/>
 		</div>

--- a/internal/templates/components/feed/video.templ
+++ b/internal/templates/components/feed/video.templ
@@ -170,8 +170,8 @@ templ VideoCardWithCarouselRemove(video types.VideoProps, opts ...FeedOption) {
 
 templ VideoThumbnail(videoID, alt string, hidden bool) {
 	<div class={ "absolute", "inset-0", "overflow-hidden", "pointer-events-none", templ.KV("blur-xl", hidden) }>
-		<object tabindex="-1" class="absolute object-cover w-full h-full transition-all duration-500 pointer-events-none bg-elev-1 group-hover:scale-110" data={ VideoThumbnailProxyURL(videoID, "sddefault") } type="image/jpeg">
-			<img class="absolute object-cover w-full h-full transition-all duration-500 pointer-events-none bg-elev-1 group-hover:scale-110" src={ VideoThumbnailProxyURL(videoID, "0") } alt={ alt } loading="eager" decoding="async"/>
+		<object tabindex="-1" class="absolute object-cover w-full h-full transition-transform duration-500 pointer-events-none bg-elev-1 group-hover:scale-110" data={ VideoThumbnailProxyURL(videoID, "sddefault") } type="image/jpeg">
+			<img class="absolute object-cover w-full h-full transition-transform duration-500 pointer-events-none bg-elev-1 group-hover:scale-110" src={ VideoThumbnailProxyURL(videoID, "0") } alt={ alt } loading="lazy" decoding="async"/>
 		</object>
 	</div>
 }

--- a/internal/templates/components/ui/layout.templ
+++ b/internal/templates/components/ui/layout.templ
@@ -32,7 +32,7 @@ func cardClass(o cardOptions) string {
 	return joinClasses(
 		base,
 		"p-4 md:p-5",
-		ifClass(o.interactive, "transition-all duration-200 ease-[var(--ease-standard)] hover:border-glass-stroke/35 hover:bg-glass-fill/55"),
+		ifClass(o.interactive, "transition-[background-color,border-color] duration-200 ease-[var(--ease-standard)] hover:border-glass-stroke/35 hover:bg-glass-fill/55"),
 		o.class,
 	)
 }

--- a/internal/templates/components/ui/progress.templ
+++ b/internal/templates/components/ui/progress.templ
@@ -4,7 +4,7 @@ import "github.com/cufee/feedlr-yt/internal/templates/components/shared"
 
 templ NavProgress() {
 	<div class="fixed top-0 z-40 w-full overflow-hidden h-fit">
-		<div id="nav-progress" class="invisible h-1 w-0 rounded-r-full bg-accent transition-all duration-[50ms] ease-[var(--ease-standard)]"></div>
+		<div id="nav-progress" class="invisible h-1 w-0 rounded-r-full bg-accent transition-[width] duration-[50ms] ease-[var(--ease-standard)]"></div>
 	</div>
 	@shared.EmbedScript(animateNavProgress())
 }

--- a/tailwind.css
+++ b/tailwind.css
@@ -45,8 +45,8 @@
     --size-video-action: 2.15rem;
     --height-video-progress: 0.55rem;
 
-    --blur-glass-sm: 10px;
-    --blur-glass-md: 20px;
+    --blur-glass-sm: 4px;
+    --blur-glass-md: 10px;
 
     --ease-standard: cubic-bezier(0.2, 0.9, 0.2, 1);
     --ease-emphasized: cubic-bezier(0.1, 0.95, 0.2, 1);
@@ -117,7 +117,7 @@
     }
 
     .ui-btn {
-        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control)] px-4 py-2.5 text-sm font-semibold text-text-primary transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50;
+        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control)] px-4 py-2.5 text-sm font-semibold text-text-primary transition-colors duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50;
     }
 
     .ui-btn-primary {
@@ -170,7 +170,7 @@
 
     .ui-toggle::after {
         content: "";
-        @apply absolute left-0.5 top-0.5 size-4.5 rounded-full bg-text-secondary transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
+        @apply absolute left-0.5 top-0.5 size-4.5 rounded-full bg-text-secondary transition-[background-color,transform] duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
     }
 
     .ui-toggle:checked {
@@ -186,7 +186,7 @@
     }
 
     .ui-tab {
-        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control-compact)] border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold text-text-primary transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-glass-fill/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 md:text-sm;
+        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control-compact)] border border-transparent bg-transparent px-3 py-1.5 text-xs font-semibold text-text-primary transition-[background-color,color] duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-glass-fill/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 md:text-sm;
     }
 
     .ui-tab-active {
@@ -206,11 +206,11 @@
     }
 
     .ui-dialog-panel {
-        @apply mx-auto my-6 w-[min(92vw,36rem)] rounded-[var(--radius-panel)] border border-glass-stroke/25 bg-glass-fill/45 p-5 shadow-[0_10px_36px_-20px_var(--color-glass-shadow)] backdrop-blur-[var(--blur-glass-md)] transition-all duration-200 ease-[var(--ease-emphasized)] motion-reduce:transition-none;
+        @apply mx-auto my-6 w-[min(92vw,36rem)] rounded-[var(--radius-panel)] border border-glass-stroke/25 bg-glass-fill/45 p-5 shadow-[0_10px_36px_-20px_var(--color-glass-shadow)] backdrop-blur-[var(--blur-glass-md)] transition-[opacity,transform] duration-200 ease-[var(--ease-emphasized)] motion-reduce:transition-none;
     }
 
     .ui-toast {
-        @apply rounded-[var(--radius-md)] border px-3 py-2 text-sm shadow-lg backdrop-blur-[var(--blur-glass-sm)] transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
+        @apply rounded-[var(--radius-md)] border px-3 py-2 text-sm shadow-lg backdrop-blur-[var(--blur-glass-sm)] transition-[opacity,transform] duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
     }
 
     .ui-toast-info {
@@ -246,7 +246,7 @@
     }
 
     .ui-nav-link {
-        @apply inline-flex h-9 w-9 items-center justify-center gap-2 rounded-[var(--radius-control)] border border-transparent bg-transparent p-0 text-sm font-semibold text-text-secondary transition-all duration-150 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-glass-fill/35 hover:text-text-primary active:bg-glass-fill/35 active:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.7];
+        @apply inline-flex h-9 w-9 items-center justify-center gap-2 rounded-[var(--radius-control)] border border-transparent bg-transparent p-0 text-sm font-semibold text-text-secondary transition-[background-color,color,border-color] duration-150 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-glass-fill/35 hover:text-text-primary active:bg-glass-fill/35 active:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.7];
     }
 
     .ui-nav-link-active {
@@ -254,7 +254,7 @@
     }
 
     .ui-nav-login {
-        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control)] bg-accent px-4 py-2.5 font-display text-sm font-semibold text-slate-950 tracking-[0.01em] transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50;
+        @apply inline-flex items-center justify-center gap-2 rounded-[var(--radius-control)] bg-accent px-4 py-2.5 font-display text-sm font-semibold text-slate-950 tracking-[0.01em] transition-colors duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none hover:bg-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-50;
     }
 
     .ui-footer-shell {
@@ -296,7 +296,9 @@
     }
 
     .ui-channel-card {
-        @apply relative flex flex-grow basis-full overflow-hidden rounded-[var(--radius-panel)] border border-glass-stroke/16 bg-surface/94 p-3.5 backdrop-blur-[var(--blur-glass-sm)] shadow-[0_8px_26px_-20px_var(--color-glass-shadow)] transition-all duration-200 ease-[var(--ease-standard)] hover:bg-surface md:basis-[calc(50%-0.75rem)] lg:basis-[calc(33.333%-0.8rem)];
+        @apply relative flex flex-grow basis-full overflow-hidden rounded-[var(--radius-panel)] border border-glass-stroke/16 bg-surface/94 p-3.5 backdrop-blur-[var(--blur-glass-sm)] shadow-[0_8px_26px_-20px_var(--color-glass-shadow)] transition-[background-color] duration-200 ease-[var(--ease-standard)] hover:bg-surface md:basis-[calc(50%-0.75rem)] lg:basis-[calc(33.333%-0.8rem)];
+        content-visibility: auto;
+        contain-intrinsic-size: auto 120px;
     }
 
     .ui-channel-overlay {
@@ -316,7 +318,7 @@
     }
 
     .ui-channel-thumb img {
-        @apply relative z-10 h-full w-full object-cover transition-all duration-500 ease-[var(--ease-standard)] group-hover:scale-110;
+        @apply relative z-10 h-full w-full object-cover transition-transform duration-500 ease-[var(--ease-standard)] group-hover:scale-110;
     }
 
     .ui-channel-thumb-skeleton {
@@ -333,7 +335,7 @@
     }
 
     .ui-channel-action-btn {
-        @apply inline-flex items-center justify-center rounded-[var(--radius-control-compact)] border border-glass-stroke/20 bg-glass-fill/24 text-text-secondary backdrop-blur-[var(--blur-glass-sm)] transition-all duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/38 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
+        @apply inline-flex items-center justify-center rounded-[var(--radius-control-compact)] border border-glass-stroke/20 bg-glass-fill/24 text-text-secondary backdrop-blur-[var(--blur-glass-sm)] transition-[background-color,color] duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/38 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
         height: 2.1rem;
         width: 2.1rem;
         padding: 0.35rem;
@@ -506,6 +508,8 @@
     .ui-video-card {
         @apply relative overflow-hidden rounded-[var(--radius-media)] bg-black/30 shadow-[0_8px_26px_-18px_var(--color-glass-shadow),inset_0_0_0_1px_rgb(255_255_255_/_0.14)];
         isolation: isolate;
+        content-visibility: auto;
+        contain-intrinsic-size: auto 300px;
     }
 
     .ui-video-card-actions {
@@ -516,7 +520,7 @@
     }
 
     .ui-video-action-btn {
-        @apply inline-flex items-center justify-center border border-glass-stroke/14 bg-black/52 text-text-secondary backdrop-blur-[var(--blur-glass-sm)] transition-all duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/40 hover:text-text-primary active:bg-glass-fill/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
+        @apply inline-flex items-center justify-center border border-glass-stroke/14 bg-black/52 text-text-secondary backdrop-blur-[var(--blur-glass-sm)] transition-[background-color,color] duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/40 hover:text-text-primary active:bg-glass-fill/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60;
         height: var(--size-video-action);
         width: var(--size-video-action);
         border-radius: var(--radius-control);
@@ -580,7 +584,7 @@
     }
 
     .ui-video-rail-btn {
-        @apply inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius-control-compact)] border border-glass-stroke/18 bg-glass-fill/22 p-0 text-text-secondary transition-all duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/35 hover:text-text-primary active:bg-glass-fill/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.8];
+        @apply inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius-control-compact)] border border-glass-stroke/18 bg-glass-fill/22 p-0 text-text-secondary transition-[background-color,color,border-color] duration-150 ease-[var(--ease-standard)] hover:bg-glass-fill/35 hover:text-text-primary active:bg-glass-fill/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 [&>svg]:h-5 [&>svg]:w-5 [&>svg]:stroke-[1.8];
     }
 
     .ui-video-rail-btn-active {
@@ -592,7 +596,7 @@
     }
 
     .ui-motion-swap {
-        @apply transition-all duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
+        @apply transition-[opacity,transform] duration-200 ease-[var(--ease-standard)] motion-reduce:transition-none;
     }
 
     .ui-motion-swap.htmx-swapping {
@@ -627,7 +631,7 @@
     }
 
     dialog .ui-motion-modal-panel {
-        @apply opacity-0 translate-y-2 scale-[0.99] transition-all duration-200 ease-[var(--ease-emphasized)] motion-reduce:transition-none;
+        @apply opacity-0 translate-y-2 scale-[0.99] transition-[opacity,transform] duration-200 ease-[var(--ease-emphasized)] motion-reduce:transition-none;
     }
 
     dialog[open] .ui-motion-modal-panel {


### PR DESCRIPTION
## Summary
- Reduce `backdrop-blur` radii (`10px→4px` sm, `20px→10px` md) to lower GPU compositing cost during scroll — especially impactful on Chrome
- Replace all `transition-all` with specific transition properties (`transition-colors`, `transition-transform`, etc.) so the browser only watches properties that actually animate
- Switch image loading from `eager` to `lazy` for video thumbnails and channel images to defer off-screen work
- Add `content-visibility: auto` to video cards and channel cards so the browser can skip rendering off-screen elements entirely

## Test plan
- [ ] Verify feed page scroll feels smoother, especially on Chrome
- [ ] Check hover animations still work on video thumbnails (scale) and buttons (color)
- [ ] Confirm thumbnails below the fold lazy-load as you scroll down
- [ ] Verify blur effect is still visible on nav, footer, action buttons, and duration chips
- [ ] Check toggle switches, tabs, and modal animations still transition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)