### PR TITLE
add usernameless passkey login with discoverable credentials

### DIFF
--- a/internal/auth/passkey.go
+++ b/internal/auth/passkey.go
@@ -58,9 +58,10 @@ func (u *User) AddCredential(credential webauthn.Credential) error {
 }
 
 func (u *User) UpdateCredential(credential webauthn.Credential) error {
-	for _, c := range u.credentials {
-		if string(c.Credential.ID) == string(credential.ID) {
-			c.Credential = credential
+	for i := range u.credentials {
+		if string(u.credentials[i].Credential.ID) == string(credential.ID) {
+			u.credentials[i].Credential = credential
+			u.credentials[i].updated = true
 			return nil
 		}
 	}

--- a/internal/server/routes/api/auth/discoverable.go
+++ b/internal/server/routes/api/auth/discoverable.go
@@ -1,0 +1,154 @@
+package auth
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/aarondl/null/v8"
+	iauth "github.com/cufee/feedlr-yt/internal/auth"
+	"github.com/cufee/feedlr-yt/internal/metrics"
+	"github.com/cufee/feedlr-yt/internal/server/handler"
+	"github.com/cufee/tpot/brewed"
+	"github.com/go-webauthn/webauthn/webauthn"
+)
+
+var DiscoverableLoginBegin brewed.Endpoint[*handler.Context] = func(ctx *handler.Context) error {
+	outcome := "error"
+	defer func() {
+		metrics.IncUserAction("discoverable_login_begin", outcome)
+		metrics.IncUserEvent("discoverable_login_begin", outcome)
+	}()
+
+	_, ok := ctx.UserID()
+	if ok {
+		outcome = "already_authenticated"
+		return ctx.Redirect("/app", http.StatusTemporaryRedirect)
+	}
+
+	session, err := ctx.SessionClient().New(ctx.Context())
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Print("ctx#SessionClient#New error", err)
+		outcome = "session_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Failed to log in")
+	}
+
+	waoptions, wasession, err := ctx.WebAuthn().BeginDiscoverableLogin()
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Print("ctx#WebAuthn#BeginDiscoverableLogin error", err)
+		outcome = "webauthn_begin_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Failed to log in")
+	}
+
+	encodedSes, err := json.Marshal(wasession)
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Print("json#Marshal error", err)
+		outcome = "session_encode_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Failed to log in")
+	}
+
+	session, err = session.UpdateMeta(ctx.Context(), map[string]string{"type": "passkey-discoverable", "data": string(encodedSes)})
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Print("session#UpdateMeta error", err)
+		outcome = "session_update_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Failed to log in")
+	}
+
+	cookie, err := session.Cookie()
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Print("session#Cookie error", err)
+		outcome = "cookie_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Failed to log in")
+	}
+	ctx.Cookie(cookie)
+	outcome = "success"
+	return ctx.JSON(waoptions)
+}
+
+var DiscoverableLoginFinish brewed.Endpoint[*handler.Context] = func(ctx *handler.Context) error {
+	outcome := "error"
+	defer func() {
+		metrics.IncUserAction("discoverable_login_finish", outcome)
+		metrics.IncUserEvent("discoverable_login_finish", outcome)
+	}()
+
+	session, ok := ctx.Session()
+	if !ok || session.Meta["type"] != "passkey-discoverable" || session.Meta["data"] == "" {
+		outcome = "missing_credentials"
+		return ctx.Status(http.StatusBadRequest).SendString("Missing credentials")
+	}
+
+	var wasession webauthn.SessionData
+	err := json.Unmarshal([]byte(session.Meta["data"]), &wasession)
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("json#Unmarshal failed", err.Error())
+		outcome = "invalid_credentials"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+
+	userStore := iauth.NewStore(ctx.Database())
+
+	// Capture the resolved user from the handler callback
+	var resolvedUser iauth.User
+	userHandler := func(rawID, userHandle []byte) (webauthn.User, error) {
+		user, err := userStore.GetUser(ctx.Context(), string(userHandle))
+		if err != nil {
+			return nil, err
+		}
+		resolvedUser = user
+		return user, nil
+	}
+
+	credential, err := ctx.WebAuthn().FinishDiscoverableLogin(userHandler, wasession, ctx.Request())
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("WebAuthn#FinishDiscoverableLogin failed", err.Error())
+		outcome = "webauthn_finish_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+
+	if credential.Authenticator.CloneWarning {
+		log.Printf("the authenticator may be cloned\n")
+	}
+
+	err = resolvedUser.UpdateCredential(*credential)
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("user#UpdateCredential failed", err.Error())
+		outcome = "credential_update_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+
+	err = userStore.SaveUser(ctx.Context(), &resolvedUser)
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("userStore#SaveUser failed", err.Error())
+		outcome = "user_save_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+
+	session, err = session.UpdateUser(ctx.Context(), null.StringFrom(resolvedUser.ID), null.String{})
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("session#UpdateUser failed", err.Error())
+		outcome = "session_update_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+
+	cookie, err := session.Cookie()
+	if err != nil {
+		ctx.ClearCookie("session_id")
+		log.Println("session#Cookie failed", err.Error())
+		outcome = "cookie_error"
+		return ctx.Status(http.StatusInternalServerError).SendString("Invalid credentials")
+	}
+	ctx.Cookie(cookie)
+	outcome = "success"
+	return ctx.SendStatus(http.StatusOK)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,8 @@ func New(db database.Client, ses *sessions.SessionClient, assets fs.FS, policy *
 		server.Post("/login/finish", toFiber(login.LoginFinish))
 		server.Post("/register/begin", toFiber(login.RegistrationBegin))
 		server.Post("/register/finish", toFiber(login.RegistrationFinish))
+		server.Post("/login/discoverable/begin", toFiber(login.DiscoverableLoginBegin))
+		server.Post("/login/discoverable/finish", toFiber(login.DiscoverableLoginFinish))
 
 		// Routes with unique auth handlers
 		server.Get("/video/:id", toFiber(root.Video))

--- a/internal/templates/pages/login.templ
+++ b/internal/templates/pages/login.templ
@@ -21,7 +21,7 @@ templ Login() {
 						"",
 						"Username",
 						ui.WithInputClass("w-full"),
-						ui.WithInputAutocomplete("username"),
+						ui.WithInputAutocomplete("username webauthn"),
 						ui.WithInputType("text"),
 						ui.WithInputMinLength(3),
 						ui.WithInputMaxLength(24),
@@ -31,6 +31,12 @@ templ Login() {
 					<button id="loginButton" type="button" class="ui-btn ui-btn-primary grow basis-1/3">Login</button>
 					<button id="registerButton" type="button" class="ui-btn ui-btn-neutral grow basis-1/3">Register</button>
 				</div>
+				<div class="flex items-center gap-2 text-text-secondary text-xs">
+					<div class="h-px flex-1 bg-border"></div>
+					<span>or</span>
+					<div class="h-px flex-1 bg-border"></div>
+				</div>
+				<button id="passkeyButton" type="button" class="ui-btn ui-btn-neutral w-full">Sign in with a passkey</button>
 			<div id="error" class="invisible w-full">
 				<div class="ui-toast ui-toast-danger w-full opacity-95">
 					<span></span>
@@ -41,12 +47,15 @@ templ Login() {
 	<script>
 		document.getElementById('registerButton').addEventListener('click', register);
 		document.getElementById('loginButton').addEventListener('click', login);
+		document.getElementById('passkeyButton').addEventListener('click', passkeyLogin);
 		document.getElementById('username').addEventListener('keyup', (e) => {
           if (e.keyCode === 13 && e.target.value?.length > 3) login();
 		});
 			document.getElementById('username').addEventListener('input', (e) => {
 			  document.getElementById('error').classList.add("invisible")
 			});
+
+			let conditionalAbort = new AbortController();
 
 			function getWebAuthnBrowser() {
 					const webAuthnBrowser = window.SimpleWebAuthnBrowser;
@@ -63,24 +72,81 @@ templ Login() {
 					alert.classList.remove("invisible")
 			}
 
+		// Discoverable login — no username required
+		async function discoverableLogin(opts = {}) {
+				try {
+						const response = await fetch('/login/discoverable/begin', {
+								method: 'POST', headers: {'Content-Type': 'application/json'},
+								body: JSON.stringify({})
+						});
+						if (!response.ok) {
+								const msg = await response.text();
+								throw new Error(msg || 'Failed to get login options from server');
+						}
+						const options = await response.json();
+
+						const webAuthnBrowser = getWebAuthnBrowser();
+						if (!webAuthnBrowser) return;
+
+						const authOpts = { optionsJSON: options.publicKey };
+						if (opts.conditional) {
+								authOpts.useBrowserAutofill = true;
+						}
+
+						const assertionResponse = await webAuthnBrowser.startAuthentication(authOpts);
+
+						const verificationResponse = await fetch('/login/discoverable/finish', {
+								method: 'POST',
+								credentials: 'same-origin',
+								headers: {'Content-Type': 'application/json'},
+								body: JSON.stringify(assertionResponse)
+						});
+
+						const msg = await verificationResponse.text();
+						if (verificationResponse.ok) {
+								window.location.href = "/app";
+						} else {
+								showMessage(msg, true);
+						}
+				} catch (error) {
+						if (error.name === 'AbortError') return;
+						showMessage('Error: ' + error.message, true);
+				}
+		}
+
+		// "Sign in with a passkey" button — modal discoverable flow
+		async function passkeyLogin() {
+				conditionalAbort.abort();
+				conditionalAbort = new AbortController();
+				await discoverableLogin();
+		}
+
+		// Conditional UI — passkeys appear in the autofill dropdown
+		async function startConditionalUI() {
+				const webAuthnBrowser = getWebAuthnBrowser();
+				if (!webAuthnBrowser) return;
+				if (!webAuthnBrowser.browserSupportsWebAuthnAutofill ||
+						!(await webAuthnBrowser.browserSupportsWebAuthnAutofill())) return;
+
+				await discoverableLogin({ conditional: true, signal: conditionalAbort.signal });
+		}
+
 		async function register() {
-				// Retrieve the username from the input field
+				conditionalAbort.abort();
+				conditionalAbort = new AbortController();
 				const username = document.getElementById('username').value;
 
 				try {
-						// Get registration options from your server. Here, we also receive the challenge.
 						const response = await fetch('/register/begin', {
 								method: 'POST', headers: {'Content-Type': 'application/json'},
 								body: JSON.stringify({username: username})
 						});
 
-						// Check if the registration options are ok.
 						if (!response.ok) {
 								const msg = await response.text();
 								throw new Error(msg|| 'Failed to get registration options from server');
 						}
 
-							// Convert the registration options to JSON.
 							const options = await response.json();
 
 							const webAuthnBrowser = getWebAuthnBrowser();
@@ -88,11 +154,8 @@ templ Login() {
 									return;
 							}
 
-							// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
-							// A new attestation is created. This also means a new public-private-key pair is created.
-							const attestationResponse = await webAuthnBrowser.startRegistration(options.publicKey);
+							const attestationResponse = await webAuthnBrowser.startRegistration({ optionsJSON: options.publicKey });
 
-						// Send attestationResponse back to server for verification and storage.
 						const verificationResponse = await fetch('/register/finish', {
 								method: 'POST',
 								credentials: 'same-origin',
@@ -117,21 +180,19 @@ templ Login() {
 		}
 
 		async function login() {
-				// Retrieve the username from the input field
+				conditionalAbort.abort();
+				conditionalAbort = new AbortController();
 				const username = document.getElementById('username').value;
 
 				try {
-						// Get login options from your server. Here, we also receive the challenge.
 						const response = await fetch('/login/begin', {
 								method: 'POST', headers: {'Content-Type': 'application/json'},
 								body: JSON.stringify({username: username})
 						});
-						// Check if the login options are ok.
 						if (!response.ok) {
 								const msg = await response.text();
 								throw new Error(msg || 'Failed to get login options from server');
 						}
-							// Convert the login options to JSON.
 							const options = await response.json();
 
 							const webAuthnBrowser = getWebAuthnBrowser();
@@ -139,11 +200,8 @@ templ Login() {
 									return;
 							}
 
-							// This triggers the browser to display the passkey / WebAuthn modal (e.g. Face ID, Touch ID, Windows Hello).
-							// A new assertionResponse is created. This also means that the challenge has been signed.
-							const assertionResponse = await webAuthnBrowser.startAuthentication(options.publicKey);
+							const assertionResponse = await webAuthnBrowser.startAuthentication({ optionsJSON: options.publicKey });
 
-						// Send assertionResponse back to server for verification.
 						const verificationResponse = await fetch('/login/finish', {
 								method: 'POST',
 								credentials: 'same-origin',
@@ -164,6 +222,8 @@ templ Login() {
 						showMessage('Error: ' + error.message, true);
 				}
 		}
+
 		</script>
 		@shared.PasskeyBrowserScript()
+		<script>startConditionalUI();</script>
 	}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cufee/feedlr-yt/internal/logic/background"
 	"github.com/cufee/feedlr-yt/internal/server"
 	"github.com/cufee/feedlr-yt/internal/sessions"
+	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/rs/zerolog/log"
 
@@ -98,6 +99,11 @@ func main() {
 		RPDisplayName: "Feedlr",
 		RPID:          strings.Split(host, ":")[0],
 		RPOrigins:     []string{origin},
+		AuthenticatorSelection: protocol.AuthenticatorSelection{
+			ResidentKey:        protocol.ResidentKeyRequirementRequired,
+			RequireResidentKey: protocol.ResidentKeyRequired(),
+			UserVerification:   protocol.VerificationPreferred,
+		},
 		Timeouts: webauthn.TimeoutsConfig{
 			Login: webauthn.TimeoutConfig{
 				Enforce:    true,


### PR DESCRIPTION
Support WebAuthn discoverable credential flow so users can sign in without entering a username. Adds conditional UI (passkey autofill) and a "Sign in with a passkey" button alongside the existing username-first flow. Also fixes UpdateCredential bug where sign counter was never persisted due to range loop value copy.